### PR TITLE
fixed parsing of ul_show_contact and allow multiple contacts per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ There are several helper methods which return conveniently formatted data:
 * cache_fetch
 * ul_show_contact
 * dlg_list
+* ps
 
 See example files for details.
 

--- a/lib/opensips/mi/response.rb
+++ b/lib/opensips/mi/response.rb
@@ -139,6 +139,25 @@ module Opensips
         @result = dr_gws_hash
         self
       end
+      
+      # returns array containing list of opensips processes
+      def ps
+        processes = []
+        @rawdata.each do |l|
+          l.slice! "Process::  "
+          h = {}
+          
+          l.split(" ", 3).each do |x| 
+            key, val = x.split("=", 2)
+            h[key.downcase.to_sym] = val
+          end
+          
+          processes << OpenStruct.new(h)
+        end
+        
+        @result = processes
+        self
+      end
 
       private
        def dr_gws_hash

--- a/lib/opensips/mi/response.rb
+++ b/lib/opensips/mi/response.rb
@@ -22,26 +22,35 @@ module Opensips
         @success = (200..299).include?(@code)
 
         # successfull responses have additional new line
-        data.pop if @success
+        #data.pop if @success
         @rawdata = data
         @result = nil
       end
       
       # Parse user locations records to Hash
       def ul_dump
-        return nil unless /^Domain:: location table=\d+ records=(\d+)$/ =~ @rawdata.shift
-        records = Hash.new
-        aor = ''
+        res = {}
+        aor = nil
+        contact = nil
+        
         @rawdata.each do |r|
-          if /\tAOR:: (?<peer>.+)$/ =~ r
-            aor = peer
-            records[aor] = Hash.new
+          next if r.start_with?("Domain")
+          r = r.strip
+          key, val = r.split(":: ")
+          
+          if key == "AOR"
+            aor = val
+            res[aor] = []
+            next
+          elsif key == "Contact"
+            contact = {}
+            res[aor] << contact
           end
-          if /^\t{2,3}(?<key>[^:]+):: (?<val>.*)$/ =~ r
-            records[aor][key] = val if aor
-          end
+          
+          contact[key.gsub(?-, ?_).downcase.to_sym] = val
         end
-        @result = records
+        
+        @result = res
         self
       end
 
@@ -76,19 +85,26 @@ module Opensips
       
       # returns Array of registered contacts
       def ul_show_contact
-        res = Array.new
+        res = {}
+        aor = nil
+        contact = nil
+        
         @rawdata.each do |r|
-          cont = Hash.new
-          r.split(?;).each do |rec|
-            if /^Contact:: (.*)$/ =~ rec
-              cont[:contact] = $1
-            else
-              key,val = rec.split ?=
-              cont[key.to_sym] = val
-            end
+          r = r.strip
+          key, val = r.split(":: ")
+          
+          if key == "AOR"
+            aor = val
+            res[aor] = []
+            next
+          elsif key == "Contact"
+            contact = {}
+            res[aor] << contact
           end
-          res << cont
+          
+          contact[key.gsub(?-, ?_).downcase.to_sym] = val
         end
+        
         @result = res
         self
       end


### PR DESCRIPTION
Tested with OpenSIPS 2.1, wasn't parsing ul_show_contact properly due to presence of tabs in returned data.   Also, there can be multiple contacts per AOR,  so the contact data needs to be in an array of hashes rather than a single hash.  Fixed for both ul_dump and ul_show_contact methods.
- successfull responses have additional new line
-        data.pop if @success

I don't see this extra line being returned, it fact it was eating up one line of useful data.   Not sure which method returned the extra line, so I left the code in, just commented out.
